### PR TITLE
Fix local variable lookup order

### DIFF
--- a/mimium-lang/src/utils/environment.rs
+++ b/mimium-lang/src/utils/environment.rs
@@ -43,7 +43,7 @@ impl<T: Clone> Environment<T> {
             .iter()
             .enumerate()
             .find(|(_level, vec)| vec.iter().any(|(n, _)| n == name))
-            .and_then(|(level, vec)| vec.iter().find(|(n, _)| n == name).map(|(_, v)| (level, v)))
+            .and_then(|(level, vec)| vec.iter().rfind(|(n, _)| n == name).map(|(_, v)| (level, v)))
         {
             None => LookupRes::None,
             Some((level, e)) if level >= self.0.len() - 1 => LookupRes::Global(e),

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -368,6 +368,18 @@ fn if_state() {
     ];
     assert_eq!(res, ans);
 }
+#[test]
+fn shadowing() {
+    let res = run_file_test_mono("shadowing.mmm", 1).unwrap();
+    let ans = vec![2.0];
+    assert_eq!(res, ans);
+}
+#[test]
+fn shadowing_assign() {
+    let res = run_file_test_mono("shadowing_assign.mmm", 1).unwrap();
+    let ans = vec![7.0];
+    assert_eq!(res, ans);
+}
 
 #[test]
 fn many_errors() {

--- a/mimium-test/tests/mmm/shadowing.mmm
+++ b/mimium-test/tests/mmm/shadowing.mmm
@@ -1,0 +1,6 @@
+//answer should be 2
+fn dsp(){
+    let phase = 1.0
+    let phase = 2.0
+    phase
+}

--- a/mimium-test/tests/mmm/shadowing_assign.mmm
+++ b/mimium-test/tests/mmm/shadowing_assign.mmm
@@ -1,0 +1,9 @@
+//answer should be 7
+
+
+fn dsp(){
+    let phase = 1.0
+    let phase = 2.0
+    phase = phase+5.0
+    phase
+}


### PR DESCRIPTION
This PR fixes that the order of variable lookup in the local scope was reversed.

(Thx @0b5vr for finding thi bug)