### PR TITLE
fixed type check  of block

### DIFF
--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -657,7 +657,10 @@ impl InferContext {
                 Self::unify_types((thent, then_loc), (elset, else_loc))
             }
             Expr::Block(expr) => expr.map_or(Ok(Type::Primitive(PType::Unit).into_id()), |e| {
-                self.infer_type(e)
+                self.env.extend(); //block creates local scope.
+                let res= self.infer_type(e);
+                self.env.to_outer();
+                res
             }),
             _ => Ok(Type::Primitive(PType::Unit).into_id()),
         };

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -407,7 +407,19 @@ fn error_include_itself() {
 fn typing_tuple_fail() {
     let res = run_error_test("typing_tuple_fail.mmm", false);
     assert_eq!(res.len(), 1);
-    assert!(res[0]
-        .get_message()
-        .contains("Type mismatch"))
+    assert!(res[0].get_message().contains("Type mismatch"))
+}
+#[test]
+fn block_local_scope() {
+    let res = run_file_test_mono("block_local_scope.mmm", 1).unwrap();
+    let ans = vec![3.0];
+    assert_eq!(res, ans);
+}
+
+
+#[test]
+fn block_local_scope_fail() {
+    let res = run_error_test("block_local_scope_fail.mmm", false);
+    assert_eq!(res.len(), 1);
+    assert!(res[0].get_message().contains("Variable local1 not found in this scope"))
 }

--- a/mimium-test/tests/mmm/block_local_scope.mmm
+++ b/mimium-test/tests/mmm/block_local_scope.mmm
@@ -1,0 +1,9 @@
+//Curly brace creates local scope. should be 3.0
+fn dsp(){
+    let test = 0
+    {
+        let local = 1.0
+    }
+    let local = 3.0
+    test + local
+}

--- a/mimium-test/tests/mmm/block_local_scope_fail.mmm
+++ b/mimium-test/tests/mmm/block_local_scope_fail.mmm
@@ -1,0 +1,8 @@
+//Curly brace creates local scope.
+fn dsp(){
+    let test = 0
+    {
+        let local1 = 1.0
+    }
+    test + local1
+}


### PR DESCRIPTION
This PR fixes the bug in the type checker so that the  block with curly brace creates local variable scope correctly.

```rust
//Curly brace creates local scope. should be 3.0
fn dsp(){
    let test = 0
    {
        let local = 1.0
    }
    let local = 3.0
    test + local
}
```

```rust
//Curly brace creates local scope. This emits error.
fn dsp(){
    let test = 0
    {
        let local1 = 1.0
    }
    test + local1 // local1 cannot be found from this scope.
}
```