### PR TITLE
Added flag to handle Initial state of `self` when time = 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v2.2.6
+
+### Bugfix
+
+- Fixed an incorrect lookup order of local variables(#116)
+- Fixed type checker so that the block with curly brace creates local variable scope(#117)
+
+### Other
+
+- Now integration test is done in wasm build too, using node.js as filesystem host
+
 ## v2.2.5
 
 ### Bugfix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-audiodriver"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "cpal",
  "mimium-lang",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-cli"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "clap",
  "colog",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-guitools"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "eframe",
  "egui",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-lang"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-midi"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "atomic_float",
  "midir",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-scheduler"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "mimium-lang",
  "mimium-test",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-symphonia"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "mimium-lang",
  "mimium-test",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-test"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "mimium-audiodriver",
  "mimium-lang",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "mimium-web"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "console_error_panic_hook",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,19 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MPL-2.0"
-version = "2.2.5"
+version = "2.2.6"
 repository = "https://github.com/tomoyanonymous/mimium-rs/"
 readme = "Readme.md"
 authors = ["Tomoya Matsuura <me@matsuuratomoya.com>"]
 
 [workspace.dependencies]
-mimium-lang = { path = "mimium-lang", version = "2.2.5" }
-mimium-audiodriver = { path = "mimium-audiodriver", version = "2.2.5" }
-mimium-midi = { path = "mimium-midi", version = "2.2.5" }
-mimium-symphonia = { path = "mimium-symphonia", version = "2.2.5" }
-mimium-scheduler = { path = "mimium-scheduler", version = "2.2.5" }
-mimium-guitools = { path = "mimium-guitools", version = "2.2.5" }
-mimium-web = { path = "mimium-web", version = "2.2.5" }
+mimium-lang = { path = "mimium-lang", version = "2.2.6" }
+mimium-audiodriver = { path = "mimium-audiodriver", version = "2.2.6" }
+mimium-midi = { path = "mimium-midi", version = "2.2.6" }
+mimium-symphonia = { path = "mimium-symphonia", version = "2.2.6" }
+mimium-scheduler = { path = "mimium-scheduler", version = "2.2.6" }
+mimium-guitools = { path = "mimium-guitools", version = "2.2.6" }
+mimium-web = { path = "mimium-web", version = "2.2.6" }
 mimium-test = { path = "mimium-test" }
 itertools = "0.13.0"
 wasm-bindgen = "0.2.93"

--- a/mimium-audiodriver/tests/getnow.rs
+++ b/mimium-audiodriver/tests/getnow.rs
@@ -10,7 +10,7 @@ use mimium_lang::{
     plugin::Plugin,
     runtime::vm::{FuncProto, Instruction, Program},
     types::{PType, Type},
-    ExecContext,
+    Config, ExecContext,
 };
 
 #[test]
@@ -51,7 +51,7 @@ fn getnow_test() {
     let times = 10;
     let mut driver = LocalBufferDriver::new(times);
     let p: Box<dyn Plugin> = Box::new(driver.get_as_plugin());
-    let mut ctx = ExecContext::new([p].into_iter(), None);
+    let mut ctx = ExecContext::new([p].into_iter(), None, Config::default());
     ctx.prepare_machine_with_bytecode(prog);
     let _iochannels = driver.init(ctx, Some(SampleRate::from(48000)));
     driver.play();

--- a/mimium-lang/benches/bench.rs
+++ b/mimium-lang/benches/bench.rs
@@ -10,7 +10,7 @@ fn main() {
 mod tests {
 
     mod runtime {
-        use mimium_lang::compiler;
+        use mimium_lang::compiler::{self, Config};
         use mimium_lang::interner::ToSymbol;
         use mimium_lang::runtime::vm::Machine;
         use test::Bencher;
@@ -46,7 +46,7 @@ fn dsp(){{
         }
 
         fn bench_runtime(b: &mut Bencher, content: &str, times: usize) {
-            let compiler = compiler::Context::new([], None);
+            let compiler = compiler::Context::new([], None, Config::default());
             let program = compiler.emit_bytecode(content).expect("ok");
             let idx = program.get_fun_index(&"dsp".to_symbol()).expect("ok");
             let mut machine = Machine::new(program, [].into_iter(), [].into_iter());
@@ -105,7 +105,7 @@ fn dsp(){{
         }
     }
     mod parse {
-        use mimium_lang::compiler;
+        use mimium_lang::compiler::{self, Config};
         use test::Bencher;
 
         fn gen_fn(fn_name: &str, n: usize) -> String {
@@ -154,7 +154,7 @@ fn dsp() {{
 
         fn bench_many_symbols(b: &mut Bencher, n: usize) {
             let content = make_many_symbols_src(n);
-            let compiler = compiler::Context::new([], None);
+            let compiler = compiler::Context::new([], None, Config::default());
             b.iter(move || {
                 let _mir = compiler.emit_mir(&content);
             });

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -95,6 +95,22 @@ pub struct ByteCodeGenerator {
     program: vm::Program,
 }
 
+/// Option for scecifying the evaluation strategy of the function that uses `self`.
+/// `SimpleState` inteprets `self` as simply internal state of the function which is initialized as 0 at time = 0.
+/// `ZeroAtInit` inteprets *the return value of the function which uses `self`* returns 0 at time = 0.
+/// For example, `| | {self + 1}` will return 1 at time = 0 in `SimpleState` mode, but 0 in `ZeroAtInit` mode.
+/// For most of the cases, `SimpleState` is the default and recommended mode.
+#[derive(Default, Debug, Clone, Copy)]
+pub enum SelfEvalMode {
+    #[default]
+    SimpleState,
+    ZeroAtInit,
+}
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Config {
+    pub self_eval_mode: SelfEvalMode,
+}
+
 fn gen_raw_int(n: &i64) -> vm::RawVal {
     let raw = {
         let iptr = n as *const i64;
@@ -143,21 +159,21 @@ impl ByteCodeGenerator {
             .map(|x| x.size * Self::word_size_for_type(x.ty) as u64)
             .sum()
     }
-    fn get_binop(&mut self, v1: &Arc<mir::Value>, v2: &Arc<mir::Value>) -> (Reg, Reg) {
-        let r1 = self.find(v1);
-        let r2 = self.find(v2);
+    fn get_binop(&mut self, v1: Arc<mir::Value>, v2: Arc<mir::Value>) -> (Reg, Reg) {
+        let r1 = self.find(&v1);
+        let r2 = self.find(&v2);
         (r1, r2)
     }
     fn emit_binop1<F>(
         &mut self,
         inst: F,
-        dst: &Arc<mir::Value>,
-        v1: &Arc<mir::Value>,
+        dst: Arc<mir::Value>,
+        v1: Arc<mir::Value>,
     ) -> Option<VmInstruction>
     where
         F: FnOnce(Reg, Reg) -> VmInstruction,
     {
-        let r1 = self.find(v1);
+        let r1 = self.find(&v1);
         let dst = self.get_destination(dst.clone(), 1);
         let i = inst(dst, r1);
         Some(i)
@@ -165,9 +181,9 @@ impl ByteCodeGenerator {
     fn emit_binop2<F>(
         &mut self,
         inst: F,
-        dst: &Arc<mir::Value>,
-        v1: &Arc<mir::Value>,
-        v2: &Arc<mir::Value>,
+        dst: Arc<mir::Value>,
+        v1: Arc<mir::Value>,
+        v2: Arc<mir::Value>,
     ) -> Option<VmInstruction>
     where
         F: FnOnce(Reg, Reg, Reg) -> VmInstruction,
@@ -303,20 +319,21 @@ impl ByteCodeGenerator {
         &mut self,
         funcproto: &mut vm::FuncProto,
         bytecodes_dst: Option<&mut Vec<VmInstruction>>,
-        mirfunc: &mir::Function,
+        mirfunc: mir::Function,
         dst: Arc<mir::Value>,
-        mirinst: &mir::Instruction,
+        mirinst: mir::Instruction,
+        config: Config,
     ) -> Option<VmInstruction> {
         match mirinst {
             mir::Instruction::Uinteger(u) => {
-                let pos = funcproto.add_new_constant(*u);
+                let pos = funcproto.add_new_constant(u);
                 Some(VmInstruction::MoveConst(
                     self.get_destination(dst, 1),
                     pos as ConstPos,
                 ))
             }
             mir::Instruction::Integer(i) => {
-                let pos = funcproto.add_new_constant(gen_raw_int(i));
+                let pos = funcproto.add_new_constant(gen_raw_int(&i));
                 Some(VmInstruction::MoveConst(
                     self.get_destination(dst, 1),
                     pos as ConstPos,
@@ -324,15 +341,15 @@ impl ByteCodeGenerator {
             }
             mir::Instruction::Float(n) => {
                 let dst = self.get_destination(dst, 1);
-                if let Ok(half_f) = HFloat::try_from(*n) {
+                if let Ok(half_f) = HFloat::try_from(n) {
                     Some(VmInstruction::MoveImmF(dst, half_f))
                 } else {
-                    let pos = funcproto.add_new_constant(gen_raw_float(n));
+                    let pos = funcproto.add_new_constant(gen_raw_float(&n));
                     Some(VmInstruction::MoveConst(dst, pos as ConstPos))
                 }
             }
             mir::Instruction::String(s) => {
-                let pos = self.program.add_new_str(*s);
+                let pos = self.program.add_new_str(s);
                 let cpos = funcproto.add_new_constant(pos as u64);
                 Some(VmInstruction::MoveConst(
                     self.get_destination(dst, 1),
@@ -340,14 +357,14 @@ impl ByteCodeGenerator {
                 ))
             }
             mir::Instruction::Alloc(t) => {
-                let size = Self::word_size_for_type(*t) as u64;
+                let size = Self::word_size_for_type(t) as u64;
                 let _ = self.vregister.push_stack(&dst, size);
                 None
             }
             mir::Instruction::Load(ptr, ty) => {
-                let d = self.get_destination(dst, Self::word_size_for_type(*ty));
-                let s = self.find_keep(ptr);
-                let size = Self::word_size_for_type(*ty);
+                let d = self.get_destination(dst, Self::word_size_for_type(ty));
+                let s = self.find_keep(&ptr);
+                let size = Self::word_size_for_type(ty);
                 match (d, s, size) {
                     (d, s, 1) if d != s => Some(VmInstruction::Move(d, s)),
                     (d, s, size) if d != s => Some(VmInstruction::MoveRange(d, s, size)),
@@ -355,9 +372,9 @@ impl ByteCodeGenerator {
                 }
             }
             mir::Instruction::Store(dst, src, ty) => {
-                let s = self.find(src);
-                let d = self.find_keep(dst);
-                let size = Self::word_size_for_type(*ty);
+                let s = self.find(&src);
+                let d = self.find_keep(&dst);
+                let size = Self::word_size_for_type(ty);
                 match (d, s, size) {
                     (d, s, 1) if d != s => Some(VmInstruction::Move(d, s)),
                     (d, s, size) if d != s => Some(VmInstruction::MoveRange(d, s, size)),
@@ -365,21 +382,21 @@ impl ByteCodeGenerator {
                 }
             }
             mir::Instruction::GetGlobal(v, ty) => {
-                let dst = self.get_destination(dst, Self::word_size_for_type(*ty));
+                let dst = self.get_destination(dst, Self::word_size_for_type(ty));
                 let idx = self.get_or_insert_global(v.clone());
                 Some(VmInstruction::GetGlobal(
                     dst,
                     idx,
-                    Self::word_size_for_type(*ty),
+                    Self::word_size_for_type(ty),
                 ))
             }
             mir::Instruction::SetGlobal(v, src, ty) => {
                 let idx = self.get_or_insert_global(v.clone());
-                let s = self.find(src);
+                let s = self.find(&src);
                 Some(VmInstruction::SetGlobal(
                     idx,
                     s,
-                    Self::word_size_for_type(*ty),
+                    Self::word_size_for_type(ty),
                 ))
             }
             mir::Instruction::GetElement {
@@ -388,16 +405,16 @@ impl ByteCodeGenerator {
                 array_idx,
                 tuple_offset,
             } => {
-                let ptr = self.find_keep(value) as usize;
-                let t_size = Self::word_size_for_type(*ty);
+                let ptr = self.find_keep(&value) as usize;
+                let t_size = Self::word_size_for_type(ty);
                 let ty = ty.to_type();
                 let tvec = ty.get_as_tuple().unwrap();
-                let tsize = Self::word_size_for_type(tvec[*tuple_offset as usize]);
-                let t_offset: u64 = tvec[0..(*tuple_offset as _)]
+                let tsize = Self::word_size_for_type(tvec[tuple_offset as usize]);
+                let t_offset: u64 = tvec[0..(tuple_offset as _)]
                     .iter()
                     .map(|t| Self::word_size_for_type(*t) as u64)
                     .sum();
-                let offset = t_size as u64 * *array_idx + t_offset;
+                let offset = t_size as u64 * array_idx + t_offset;
                 let address = (ptr + offset as usize) as Reg;
                 self.vregister
                     .get_top()
@@ -406,15 +423,15 @@ impl ByteCodeGenerator {
                 None
             }
             mir::Instruction::Call(v, args, r_ty) => {
-                let rsize = Self::word_size_for_type(*r_ty);
+                let rsize = Self::word_size_for_type(r_ty);
                 match v.as_ref() {
                     mir::Value::Register(_address) => {
                         let bytecodes_dst =
                             bytecodes_dst.unwrap_or_else(|| funcproto.bytecodes.as_mut());
                         let d = self.get_destination(dst.clone(), rsize);
-                        let s = self.find(v);
+                        let s = self.find(&v);
                         bytecodes_dst.push(VmInstruction::Move(d, s));
-                        let (fadd, argsize) = self.prepare_function(bytecodes_dst, &dst, args);
+                        let (fadd, argsize) = self.prepare_function(bytecodes_dst, &dst, &args);
                         Some(VmInstruction::Call(fadd, argsize, rsize))
                     }
                     mir::Value::Function(_idx) => {
@@ -423,21 +440,21 @@ impl ByteCodeGenerator {
                     mir::Value::ExtFunction(label, _ty) => {
                         //todo: use btreemap
                         let (dst, argsize, nret) =
-                            self.prepare_extfun(funcproto, bytecodes_dst, dst, args, *label, *r_ty);
+                            self.prepare_extfun(funcproto, bytecodes_dst, dst, &args, *label, r_ty);
                         Some(VmInstruction::CallExtFun(dst, argsize, nret))
                     }
                     _ => unreachable!(),
                 }
             }
             mir::Instruction::CallCls(f, args, r_ty) => {
-                let rsize = Self::word_size_for_type(*r_ty);
+                let rsize = Self::word_size_for_type(r_ty);
                 match f.as_ref() {
                     mir::Value::Register(_address) => {
                         let bytecodes_dst =
                             bytecodes_dst.unwrap_or_else(|| funcproto.bytecodes.as_mut());
 
-                        let (fadd, argsize) = self.prepare_function(bytecodes_dst, f, args);
-                        let s = self.find(f);
+                        let (fadd, argsize) = self.prepare_function(bytecodes_dst, &f, &args);
+                        let s = self.find(&f);
                         let d = self.get_destination(dst.clone(), rsize);
                         bytecodes_dst.push(VmInstruction::CallCls(fadd, argsize, rsize));
                         match rsize {
@@ -451,21 +468,21 @@ impl ByteCodeGenerator {
                     }
                     mir::Value::ExtFunction(label, _ty) => {
                         let (dst, argsize, nret) =
-                            self.prepare_extfun(funcproto, bytecodes_dst, dst, args, *label, *r_ty);
+                            self.prepare_extfun(funcproto, bytecodes_dst, dst, &args, *label, r_ty);
                         Some(VmInstruction::CallExtFun(dst, argsize, nret))
                     }
                     _ => unreachable!(),
                 }
             }
             mir::Instruction::Closure(idxcell) => {
-                let idx = self.find(idxcell);
+                let idx = self.find(&idxcell);
                 let dst = self.get_destination(dst, 1);
                 Some(VmInstruction::Closure(dst, idx))
             }
             mir::Instruction::CloseUpValues(src, ty) => {
                 // src might contain multiple upvalues (e.g. tuple)
                 let flattened = ty.flatten();
-                let base = self.vregister.find_keep(src).unwrap();
+                let base = self.vregister.find_keep(&src).unwrap();
 
                 let mut offset = 0;
                 let bytecodes_dst = bytecodes_dst.unwrap_or_else(|| funcproto.bytecodes.as_mut());
@@ -479,15 +496,15 @@ impl ByteCodeGenerator {
                 None
             }
             mir::Instruction::GetUpValue(i, ty) => {
-                let upval = &mirfunc.upindexes[*i as usize];
+                let upval = &mirfunc.upindexes[i as usize];
                 let v = self.find_upvalue(upval);
-                let size: u8 = Self::word_size_for_type(*ty);
+                let size: u8 = Self::word_size_for_type(ty);
                 let ouv = mir::OpenUpValue {
                     pos: v as usize,
                     size,
                     is_closure: ty.to_type().is_function(),
                 };
-                if let Some(ui) = funcproto.upindexes.get_mut(*i as usize) {
+                if let Some(ui) = funcproto.upindexes.get_mut(i as usize) {
                     *ui = ouv;
                 } else {
                     funcproto.upindexes.push(ouv);
@@ -495,29 +512,29 @@ impl ByteCodeGenerator {
                 let d = self.vregister.get_top().add_newvalue_range(&dst, size as _);
                 Some(VmInstruction::GetUpValue(
                     d,
-                    *i as Reg,
-                    Self::word_size_for_type(*ty),
+                    i as Reg,
+                    Self::word_size_for_type(ty),
                 ))
             }
             mir::Instruction::SetUpValue(dst, src, ty) => {
-                let upval = &mirfunc.upindexes[*dst as usize];
+                let upval = &mirfunc.upindexes[dst as usize];
                 let v = self.find_upvalue(upval);
-                let size: u8 = Self::word_size_for_type(*ty);
+                let size: u8 = Self::word_size_for_type(ty);
                 let ouv = mir::OpenUpValue {
                     pos: v as usize,
                     size,
                     is_closure: ty.to_type().is_function(),
                 };
-                if let Some(ui) = funcproto.upindexes.get_mut(*dst as usize) {
+                if let Some(ui) = funcproto.upindexes.get_mut(dst as usize) {
                     *ui = ouv;
                 } else {
                     funcproto.upindexes.push(ouv);
                 }
-                let s = self.find(src);
+                let s = self.find(&src);
                 Some(VmInstruction::SetUpValue(
-                    *dst as Reg,
+                    dst as Reg,
                     s,
-                    Self::word_size_for_type(*ty),
+                    Self::word_size_for_type(ty),
                 ))
             }
             mir::Instruction::PushStateOffset(v) => {
@@ -531,55 +548,58 @@ impl ByteCodeGenerator {
                 Some(VmInstruction::PopStatePos(state_size))
             }
             mir::Instruction::GetState(ty) => {
-                let size = Self::word_size_for_type(*ty);
+                let size = Self::word_size_for_type(ty);
                 let d = self.vregister.push_stack(&dst, size as _);
                 Some(VmInstruction::GetState(d, size))
             }
 
             mir::Instruction::JmpIf(cond, tbb, ebb, pbb) => {
-                let c = self.find(cond);
+                let c = self.find(&cond);
 
                 // TODO: to allow &mut match, but there should be nicer way...
                 let mut bytecodes_dst = bytecodes_dst;
 
                 let mut then_bytecodes: Vec<VmInstruction> = vec![];
                 let mut else_bytecodes: Vec<VmInstruction> = vec![];
-                mirfunc.body[*tbb as usize]
+                mirfunc.body[tbb as usize]
                     .0
                     .iter()
                     .for_each(|(dst, t_inst)| {
-                        if let Some(inst) = self.emit_instruction(
+                        let res = self.emit_instruction(
                             funcproto,
                             Some(&mut then_bytecodes),
-                            mirfunc,
+                            mirfunc.clone(),
                             dst.clone(),
-                            t_inst,
-                        ) {
+                            t_inst.clone(),
+                            config,
+                        );
+                        if let Some(inst) = res {
                             then_bytecodes.push(inst);
                         }
                     });
 
-                mirfunc.body[*ebb as usize]
+                mirfunc.body[ebb as usize]
                     .0
                     .iter()
                     .for_each(|(dst, t_inst)| {
                         if let Some(inst) = self.emit_instruction(
                             funcproto,
                             Some(&mut else_bytecodes),
-                            mirfunc,
+                            mirfunc.clone(),
                             dst.clone(),
-                            t_inst,
+                            t_inst.clone(),
+                            config,
                         ) {
                             else_bytecodes.push(inst);
                         };
                     });
-                let phiblock = &mirfunc.body[*pbb as usize].0;
+                let phiblock = &mirfunc.body[pbb as usize].0;
                 let (phidst, pinst) = phiblock.first().unwrap();
                 let phi = self.vregister.add_newvalue(phidst);
                 if let mir::Instruction::Phi(t, e) = pinst {
-                    let t = self.find(t);
+                    let t = self.find(&t);
                     then_bytecodes.push(VmInstruction::Move(phi, t));
-                    let e = self.find(e);
+                    let e = self.find(&e);
                     else_bytecodes.push(VmInstruction::Move(phi, e));
                 } else {
                     unreachable!("Unexpected inst: {pinst:?}");
@@ -604,9 +624,14 @@ impl ByteCodeGenerator {
                 }
 
                 phiblock.iter().skip(1).for_each(|(dst, p_inst)| {
-                    if let Some(inst) =
-                        self.emit_instruction(funcproto, None, mirfunc, dst.clone(), p_inst)
-                    {
+                    if let Some(inst) = self.emit_instruction(
+                        funcproto,
+                        None,
+                        mirfunc.clone(),
+                        dst.clone(),
+                        p_inst.clone(),
+                        config,
+                    ) {
                         match &mut bytecodes_dst {
                             Some(dst) => dst.push(inst),
                             None => funcproto.bytecodes.push(inst),
@@ -615,68 +640,76 @@ impl ByteCodeGenerator {
                 });
                 None
             }
-            mir::Instruction::Jmp(offset) => Some(VmInstruction::Jmp(*offset)),
+            mir::Instruction::Jmp(offset) => Some(VmInstruction::Jmp(offset)),
             mir::Instruction::Phi(_, _) => {
                 unreachable!()
             }
             mir::Instruction::Return(v, rty) => {
-                let nret = Self::word_size_for_type(*rty);
+                let nret = Self::word_size_for_type(rty);
                 let inst = match v.as_ref() {
                     mir::Value::None => VmInstruction::Return0,
-                    _ => VmInstruction::Return(self.find(v), nret),
+                    _ => VmInstruction::Return(self.find(&v), nret),
                 };
                 Some(inst)
             }
             mir::Instruction::ReturnFeed(new, rty) => {
-                //for returning always 0 at t=0
-                let old = self.vregister.add_newvalue(&dst);
+                let size = Self::word_size_for_type(rty);
                 let bytecodes_dst = bytecodes_dst.unwrap_or_else(|| funcproto.bytecodes.as_mut());
-                let size = Self::word_size_for_type(*rty);
-                bytecodes_dst.push(VmInstruction::GetState(old, size));
-                let new = self.find(new);
-                bytecodes_dst.push(VmInstruction::SetState(new, size));
-                Some(VmInstruction::Return(old, size))
-                // Some(VmInstruction::Return(new, nret))
+                match config.self_eval_mode {
+                    SelfEvalMode::SimpleState => {
+                        let new = self.find(&new);
+                        bytecodes_dst.push(VmInstruction::SetState(new, size));
+                        Some(VmInstruction::Return(new, size))
+                    }
+                    SelfEvalMode::ZeroAtInit => {
+                        //for returning always 0 at t=0
+                        let old = self.vregister.add_newvalue(&dst);
+                        bytecodes_dst.push(VmInstruction::GetState(old, size));
+                        let new = self.find(&new);
+                        bytecodes_dst.push(VmInstruction::SetState(new, size));
+                        Some(VmInstruction::Return(old, size))
+                    }
+                }
             }
             mir::Instruction::Delay(max, src, time) => {
-                let s = self.find(src);
-                let t = self.find(time);
+                let s = self.find(&src);
+                let t = self.find(&time);
 
                 let dst = self.vregister.add_newvalue(&dst);
-                funcproto.delay_sizes.push(*max);
+                funcproto.delay_sizes.push(max);
                 Some(VmInstruction::Delay(dst, s, t))
             }
             mir::Instruction::Mem(src) => {
-                let s = self.find(src);
+                let s = self.find(&src);
                 let dst = self.vregister.add_newvalue(&dst);
                 Some(VmInstruction::Mem(dst, s))
             }
-            mir::Instruction::NegF(v1) => self.emit_binop1(VmInstruction::NegF, &dst, v1),
-            mir::Instruction::AddF(v1, v2) => self.emit_binop2(VmInstruction::AddF, &dst, v1, v2),
-            mir::Instruction::SubF(v1, v2) => self.emit_binop2(VmInstruction::SubF, &dst, v1, v2),
-            mir::Instruction::MulF(v1, v2) => self.emit_binop2(VmInstruction::MulF, &dst, v1, v2),
-            mir::Instruction::DivF(v1, v2) => self.emit_binop2(VmInstruction::DivF, &dst, v1, v2),
-            mir::Instruction::ModF(v1, v2) => self.emit_binop2(VmInstruction::ModF, &dst, v1, v2),
-            mir::Instruction::PowF(v1, v2) => self.emit_binop2(VmInstruction::PowF, &dst, v1, v2),
-            mir::Instruction::LogF(v1) => self.emit_binop1(VmInstruction::LogF, &dst, v1),
+            mir::Instruction::NegF(v1) => self.emit_binop1(VmInstruction::NegF, dst, v1),
+            mir::Instruction::AddF(v1, v2) => self.emit_binop2(VmInstruction::AddF, dst, v1, v2),
+            mir::Instruction::SubF(v1, v2) => self.emit_binop2(VmInstruction::SubF, dst, v1, v2),
+            mir::Instruction::MulF(v1, v2) => self.emit_binop2(VmInstruction::MulF, dst, v1, v2),
+            mir::Instruction::DivF(v1, v2) => self.emit_binop2(VmInstruction::DivF, dst, v1, v2),
+            mir::Instruction::ModF(v1, v2) => self.emit_binop2(VmInstruction::ModF, dst, v1, v2),
+            mir::Instruction::PowF(v1, v2) => self.emit_binop2(VmInstruction::PowF, dst, v1, v2),
+            mir::Instruction::LogF(v1) => self.emit_binop1(VmInstruction::LogF, dst, v1),
 
-            mir::Instruction::SinF(v1) => self.emit_binop1(VmInstruction::SinF, &dst, v1),
-            mir::Instruction::CosF(v1) => self.emit_binop1(VmInstruction::CosF, &dst, v1),
-            mir::Instruction::AbsF(v1) => self.emit_binop1(VmInstruction::AbsF, &dst, v1),
-            mir::Instruction::SqrtF(v1) => self.emit_binop1(VmInstruction::SqrtF, &dst, v1),
-            mir::Instruction::AddI(v1, v2) => self.emit_binop2(VmInstruction::AddI, &dst, v1, v2),
-            mir::Instruction::SubI(v1, v2) => self.emit_binop2(VmInstruction::SubI, &dst, v1, v2),
-            mir::Instruction::MulI(v1, v2) => self.emit_binop2(VmInstruction::MulI, &dst, v1, v2),
-            mir::Instruction::DivI(v1, v2) => self.emit_binop2(VmInstruction::DivI, &dst, v1, v2),
-            mir::Instruction::ModI(v1, v2) => self.emit_binop2(VmInstruction::ModI, &dst, v1, v2),
-            mir::Instruction::Gt(v1, v2) => self.emit_binop2(VmInstruction::Gt, &dst, v1, v2),
-            mir::Instruction::Ge(v1, v2) => self.emit_binop2(VmInstruction::Ge, &dst, v1, v2),
-            mir::Instruction::Lt(v1, v2) => self.emit_binop2(VmInstruction::Lt, &dst, v1, v2),
-            mir::Instruction::Le(v1, v2) => self.emit_binop2(VmInstruction::Le, &dst, v1, v2),
-            mir::Instruction::Eq(v1, v2) => self.emit_binop2(VmInstruction::Eq, &dst, v1, v2),
-            mir::Instruction::Ne(v1, v2) => self.emit_binop2(VmInstruction::Ne, &dst, v1, v2),
-            mir::Instruction::And(v1, v2) => self.emit_binop2(VmInstruction::And, &dst, v1, v2),
-            mir::Instruction::Or(v1, v2) => self.emit_binop2(VmInstruction::Or, &dst, v1, v2),
+            mir::Instruction::SinF(v1) => self.emit_binop1(VmInstruction::SinF, dst, v1),
+            mir::Instruction::CosF(v1) => self.emit_binop1(VmInstruction::CosF, dst, v1),
+            mir::Instruction::AbsF(v1) => self.emit_binop1(VmInstruction::AbsF, dst, v1),
+            mir::Instruction::SqrtF(v1) => self.emit_binop1(VmInstruction::SqrtF, dst, v1),
+            mir::Instruction::AddI(v1, v2) => self.emit_binop2(VmInstruction::AddI, dst, v1, v2),
+            mir::Instruction::SubI(v1, v2) => self.emit_binop2(VmInstruction::SubI, dst, v1, v2),
+            mir::Instruction::MulI(v1, v2) => self.emit_binop2(VmInstruction::MulI, dst, v1, v2),
+            mir::Instruction::DivI(v1, v2) => self.emit_binop2(VmInstruction::DivI, dst, v1, v2),
+            mir::Instruction::ModI(v1, v2) => self.emit_binop2(VmInstruction::ModI, dst, v1, v2),
+            mir::Instruction::Gt(v1, v2) => self.emit_binop2(VmInstruction::Gt, dst, v1, v2),
+            mir::Instruction::Ge(v1, v2) => self.emit_binop2(VmInstruction::Ge, dst, v1, v2),
+            mir::Instruction::Lt(v1, v2) => self.emit_binop2(VmInstruction::Lt, dst, v1, v2),
+            mir::Instruction::Le(v1, v2) => self.emit_binop2(VmInstruction::Le, dst, v1, v2),
+            mir::Instruction::Eq(v1, v2) => self.emit_binop2(VmInstruction::Eq, dst, v1, v2),
+            mir::Instruction::Ne(v1, v2) => self.emit_binop2(VmInstruction::Ne, dst, v1, v2),
+            mir::Instruction::And(v1, v2) => self.emit_binop2(VmInstruction::And, dst, v1, v2),
+            mir::Instruction::Or(v1, v2) => self.emit_binop2(VmInstruction::Or, dst, v1, v2),
 
             _ => {
                 unimplemented!()
@@ -687,6 +720,7 @@ impl ByteCodeGenerator {
         &mut self,
         mirfunc: &mir::Function,
         fidx: usize,
+        config: Config,
     ) -> (Symbol, vm::FuncProto) {
         log::trace!("generating function {}", mirfunc.label.0);
         let state_size = Self::calc_state_size(&mirfunc.state_sizes);
@@ -710,21 +744,28 @@ impl ByteCodeGenerator {
         // succeeding block will be compiled recursively
         let block = &mirfunc.body[0];
         block.0.iter().for_each(|(dst, inst)| {
-            let newinst = self.emit_instruction(&mut func, None, mirfunc, dst.clone(), inst);
+            let newinst = self.emit_instruction(
+                &mut func,
+                None,
+                mirfunc.clone(),
+                dst.clone(),
+                inst.clone(),
+                config,
+            );
             if let Some(i) = newinst {
                 func.bytecodes.push(i);
             }
         });
         (mirfunc.label, func)
     }
-    pub fn generate(&mut self, mir: Mir) -> vm::Program {
+    pub fn generate(&mut self, mir: Mir, config: Config) -> vm::Program {
         self.program.global_fn_table = mir
             .functions
             .iter()
             .enumerate()
             .map(|(i, func)| {
                 self.fnmap.insert(func.label, i);
-                self.generate_funcproto(func, i)
+                self.generate_funcproto(func, i, config)
             })
             .collect();
         self.program.file_path = mir.file_path;
@@ -786,9 +827,9 @@ fn optimize(program: vm::Program) -> vm::Program {
     // remove_redundunt_mov(program);
     program
 }
-pub fn gen_bytecode(mir: mir::Mir) -> vm::Program {
+pub fn gen_bytecode(mir: mir::Mir, config: Config) -> vm::Program {
     let mut generator = ByteCodeGenerator::default();
-    let program = generator.generate(mir);
+    let program = generator.generate(mir, config);
     optimize(program)
 }
 
@@ -832,7 +873,8 @@ mod test {
         func.body = vec![block];
         src.functions.push(func);
         let mut generator = ByteCodeGenerator::default();
-        let res = generator.generate(src);
+        let config = Config::default();
+        let res = generator.generate(src, config);
 
         let mut answer = vm::Program {
             iochannels: Some(IoChannelInfo {

--- a/mimium-symphonia/tests/integration_test.rs
+++ b/mimium-symphonia/tests/integration_test.rs
@@ -30,7 +30,7 @@ fn test_readwav_interp() {
         .map(|f| (*f * 1000.0).round() as u32)
         .collect::<Vec<_>>();
     let mut ans = (0u32..100)
-        .map(|x| (x * 10 + 5).min(990))
+    .map(|x| (x * 10 + 5).min(990))
         .collect::<Vec<_>>();
     ans.push(0); //0 should be returned when the index exceeds the boundary
     assert_eq!(res_int, ans);

--- a/mimium-symphonia/tests/mmm/loadwav.mmm
+++ b/mimium-symphonia/tests/mmm/loadwav.mmm
@@ -1,8 +1,9 @@
 //gen_sampler_mono returns higher-order function that takes playback position in samples as an argument
 let sampler = gen_sampler_mono("../assets/count_100_by_0_01_f32_48000Hz.wav")
 fn counter(){
-    self+1.0
+    self+1.0 
 }
+//add -1.0 offset so that the counter start from 0 at t=0
 fn dsp(){
-    counter() |> sampler
+    counter()-1.0 |> sampler
 }

--- a/mimium-symphonia/tests/mmm/loadwav_interp.mmm
+++ b/mimium-symphonia/tests/mmm/loadwav_interp.mmm
@@ -3,5 +3,5 @@ fn counter(){
     self+1.0
 }
 fn dsp(){
-    counter()+0.5 |> sampler
+    counter()-1.0+0.5 |> sampler
 }

--- a/mimium-test/src/lib.rs
+++ b/mimium-test/src/lib.rs
@@ -10,7 +10,7 @@ use mimium_lang::{
         fileloader,
         metadata::Location,
     },
-    ExecContext,
+    Config, ExecContext,
 };
 
 pub fn run_bytecode_test(
@@ -33,7 +33,7 @@ pub fn run_bytecode_test_multiple(
     times: u64,
     stereo: bool,
 ) -> Result<Vec<f64>, Vec<Box<dyn ReportableError>>> {
-    let mut ctx = ExecContext::new([].into_iter(), None);
+    let mut ctx = ExecContext::new([].into_iter(), None, Config::default());
     ctx.prepare_machine_with_bytecode(bytecodes);
     let machine = ctx.get_vm_mut().unwrap();
     let _retcode = machine.execute_main();
@@ -59,6 +59,7 @@ pub fn run_source_with_plugins(
     let mut ctx = ExecContext::new(
         plugins.chain([audiodriverplug]),
         path.map(|s| s.to_symbol()),
+        Config::default(),
     );
     if with_scheduler {
         ctx.add_system_plugin(mimium_scheduler::get_default_scheduler_plugin());
@@ -84,7 +85,7 @@ pub fn run_source_test(
     stereo: bool,
     path: Option<Symbol>,
 ) -> Result<Vec<f64>, Vec<Box<dyn ReportableError>>> {
-    let mut ctx = ExecContext::new([].into_iter(), path);
+    let mut ctx = ExecContext::new([].into_iter(), path, Config::default());
 
     ctx.prepare_machine(src)?;
     let bytecode = ctx.take_vm().unwrap().prog;
@@ -184,7 +185,11 @@ pub fn run_file_test_stereo(path: &'static str, times: u64) -> Option<Vec<f64>> 
 pub fn test_state_sizes<T: IntoIterator<Item = (&'static str, u64)>>(path: &'static str, ans: T) {
     let state_sizes: HashMap<&str, u64> = HashMap::from_iter(ans);
     let (file, src) = load_src(path);
-    let mut ctx = ExecContext::new([].into_iter(), Some(file.to_str().unwrap().to_symbol()));
+    let mut ctx = ExecContext::new(
+        [].into_iter(),
+        Some(file.to_str().unwrap().to_symbol()),
+        Config::default(),
+    );
     ctx.prepare_machine(&src).unwrap();
     let bytecode = ctx.take_vm().expect("failed to emit bytecode").prog;
     // let bytecode = match ctx.compiler.emit_bytecode(&src) {

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -76,33 +76,33 @@ fn pipe() {
 #[wasm_bindgen_test(unsupported = test)]
 fn counter() {
     let res = run_file_test_mono("counter.mmm", 10).unwrap();
-    let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    let ans = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
     assert_eq!(res, ans);
 }
 #[wasm_bindgen_test(unsupported = test)]
 fn statefn() {
     let res = run_file_test_mono("statefn.mmm", 10).unwrap();
-    let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    let ans = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
     assert_eq!(res, ans);
 }
 #[wasm_bindgen_test(unsupported = test)]
 fn statefn2_same() {
     let res = run_file_test_mono("statefn2_same.mmm", 3).unwrap();
-    let ans = vec![0.0, 6.0, 12.0];
+    let ans = vec![6.0, 12.0, 18.0];
     assert_eq!(res, ans);
 }
 
 #[wasm_bindgen_test(unsupported = test)]
 fn statefn2() {
     let res = run_file_test_mono("statefn2.mmm", 3).unwrap();
-    let ans = vec![0.0, 8.0, 16.0];
+    let ans = vec![8.0, 16.0, 24.];
     assert_eq!(res, ans);
 }
 
 #[wasm_bindgen_test(unsupported = test)]
 fn loopcounter() {
     let res = run_file_test_mono("loopcounter.mmm", 10).unwrap();
-    let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 0.0, 1.0, 2.0, 3.0, 4.0];
+    let ans = vec![1.0, 2.0, 3.0, 4.0, 0.0, 1.0, 2.0, 3.0, 4.0, 0.0];
     assert_eq!(res, ans);
 }
 #[wasm_bindgen_test(unsupported = test)]
@@ -168,7 +168,7 @@ fn closure_tuple_escape() {
 #[wasm_bindgen_test(unsupported = test)]
 fn state_tuple() {
     let res = run_file_test_stereo("state_tuple.mmm", 3).unwrap();
-    let ans = vec![0.0, 0.0, 1.0, 2.0, 2.0, 4.0];
+    let ans = vec![1.0, 2.0, 2.0, 4.0, 3.0, 6.0];
     assert_eq!(res, ans);
 }
 #[wasm_bindgen_test(unsupported = test)]
@@ -209,7 +209,6 @@ fn closure_argument() {
 fn stateful_closure() {
     let res = run_file_test_mono("stateful_closure.mmm", 10).unwrap();
     let ans = vec![
-        20.0,
         20.3,
         20.599999999999998,
         20.900000000000002,
@@ -219,6 +218,7 @@ fn stateful_closure() {
         22.099999999999998,
         22.400000000000002,
         22.7,
+        23.0,
     ];
     assert_eq!(res, ans);
 }
@@ -258,7 +258,6 @@ fn closure_counter_tuple() {
 fn hof_state() {
     let res = run_file_test_mono("hof_state.mmm", 10).unwrap();
     let ans = vec![
-        0.0,
         0.6000000000000001,
         1.2000000000000002,
         1.8000000000000003,
@@ -268,6 +267,7 @@ fn hof_state() {
         4.199999999999999,
         4.8,
         5.3999999999999995,
+        5.999999999999999,
     ];
     assert_eq!(res, ans);
 }
@@ -276,7 +276,6 @@ fn hof_state() {
 fn hof_infer() {
     let res = run_file_test_mono("hof_infer.mmm", 10).unwrap();
     let ans = vec![
-        0.0,
         0.6000000000000001,
         1.2000000000000002,
         1.8000000000000003,
@@ -286,6 +285,7 @@ fn hof_infer() {
         4.199999999999999,
         4.8,
         5.3999999999999995,
+        5.999999999999999,
     ];
     assert_eq!(res, ans);
 }
@@ -309,8 +309,8 @@ fn tuple_args() {
 fn fb_mem() {
     let res = run_file_test_stereo("fb_mem.mmm", 10).unwrap();
     let ans = vec![
-        0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2.0, 1.0, 3.0, 2.0, 4.0, 3.0, 5.0, 4.0, 6.0, 5.0, 7.0, 6.0,
-        8.0, 7.0,
+        1.0, 0.0, 2.0, 1.0, 3.0, 2.0, 4.0, 3.0, 5.0, 4.0, 6.0, 5.0, 7.0, 6.0, 8.0, 7.0, 9.0, 8.0,
+        10.0, 9.0,
     ];
     assert_eq!(res, ans);
 }
@@ -319,8 +319,8 @@ fn fb_mem() {
 fn fb_mem2() {
     let res = run_file_test_stereo("fb_mem2.mmm", 10).unwrap();
     let ans = vec![
-        0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 1.0, 4.0, 2.0, 5.0, 3.0, 6.0, 4.0, 7.0, 5.0,
-        8.0, 6.0,
+        1.0, 0.0, 2.0, 0.0, 3.0, 1.0, 4.0, 2.0, 5.0, 3.0, 6.0, 4.0, 7.0, 5.0, 8.0, 6.0, 9.0, 7.0,
+        10.0, 8.0,
     ];
     assert_eq!(res, ans);
 }
@@ -336,27 +336,27 @@ fn fb_mem3_state_size() {
 #[wasm_bindgen_test(unsupported = test)]
 fn fb_and_stateful_call() {
     let res = run_file_test_mono("fb_and_stateful_call.mmm", 10).unwrap();
-    let ans = vec![0.0, 0.0, 1.0, 3.0, 6.0, 10.0, 15.0, 21.0, 28.0, 36.0];
+    let ans = vec![1.0, 3.0, 6.0, 10.0, 15.0, 21.0, 28.0, 36.0, 45.0, 55.0];
     assert_eq!(res, ans);
 }
 
 #[wasm_bindgen_test(unsupported = test)]
 fn delay() {
     let res = run_file_test_mono("delay.mmm", 10).unwrap();
-    let ans = vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0];
+    let ans = vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
     assert_eq!(res, ans);
 }
 #[wasm_bindgen_test(unsupported = test)]
 fn delay2() {
     let res = run_file_test_mono("delay2.mmm", 10).unwrap();
-    let ans = vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0];
+    let ans = vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
     assert_eq!(res, ans);
 }
 
 #[wasm_bindgen_test(unsupported = test)]
 fn include_file() {
     let res = run_file_test_mono("test_include.mmm", 10).unwrap();
-    let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    let ans = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
     assert_eq!(res, ans);
 }
 
@@ -364,8 +364,8 @@ fn include_file() {
 fn if_state() {
     let res = run_file_test_stereo("if_state.mmm", 10).unwrap();
     let ans = vec![
-        0.0, 0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 5.0, 0.0, 6.0, 0.0, 7.0, 0.0, 8.0, 0.0,
-        9.0, 0.0,
+        1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 5.0, 0.0, 6.0, 0.0, 7.0, 0.0, 8.0, 0.0, 9.0, 0.0,
+        10.0, 0.0,
     ];
     assert_eq!(res, ans);
 }
@@ -422,10 +422,11 @@ fn block_local_scope() {
     assert_eq!(res, ans);
 }
 
-
 #[wasm_bindgen_test(unsupported = test)]
 fn block_local_scope_fail() {
     let res = run_error_test("block_local_scope_fail.mmm", false);
     assert_eq!(res.len(), 1);
-    assert!(res[0].get_message().contains("Variable local1 not found in this scope"))
+    assert!(res[0]
+        .get_message()
+        .contains("Variable local1 not found in this scope"))
 }

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -430,3 +430,13 @@ fn block_local_scope_fail() {
         .get_message()
         .contains("Variable local1 not found in this scope"))
 }
+
+#[wasm_bindgen_test(unsupported = test)]
+fn test_phase_reset() {
+    let res = run_file_test_stereo("test_phase_reset.mmm", 10).unwrap();
+    let ans = vec![
+        0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 5.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0,
+        1.0, 0.0,
+    ];
+    assert_eq!(res, ans);
+}

--- a/mimium-test/tests/mmm/test_phase_reset.mmm
+++ b/mimium-test/tests/mmm/test_phase_reset.mmm
@@ -1,0 +1,22 @@
+// run this test with self_eval_mode=simplestate.
+// ch0: 0,0,0,0,0,1,1,1,1,1
+// ch1: 1,2,3,4,5,0,0,0,0,0
+// if run with --self-init-0 from a command line, the result will be:
+// ch0: 0,0,0,0,0,0,1,1,1,1
+// ch1: 0,1,2,3,4,5,0,0,0,0
+fn counter(){
+    self+1
+}
+fn integ(x, reset) {
+  if (reset) {
+    0
+  } else {
+    self + x
+  }
+}
+fn dsp(){
+    let count  = counter()
+    let reset = count > 5
+    let r = integ(1,reset)
+    (reset,r)
+}

--- a/mimium-test/tests/scheduler_test.rs
+++ b/mimium-test/tests/scheduler_test.rs
@@ -39,7 +39,7 @@ fn scheduler_counter_indirect() {
 #[wasm_bindgen_test(unsupported = test)]
 fn scheduler_reactive() {
     let res = run_file_with_scheduler("scheduler_reactive.mmm", 10).unwrap();
-    let ans = vec![0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0];
+    let ans = vec![0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0];
     assert_eq!(res, ans);
 }
 
@@ -47,7 +47,7 @@ fn scheduler_reactive() {
 fn prep_gc_test_machine(times: usize, src: &str) -> LocalBufferDriver {
     let mut driver = LocalBufferDriver::new(times);
     let driverplug: Box<dyn Plugin> = Box::new(driver.get_as_plugin());
-    let mut ctx = ExecContext::new([driverplug].into_iter(), None);
+    let mut ctx = ExecContext::new([driverplug].into_iter(), None, Default::default());
     ctx.add_system_plugin(mimium_scheduler::get_default_scheduler_plugin());
     let _ = ctx.prepare_machine(src);
     let _ = ctx.run_main();

--- a/mimium-web/src/lib.rs
+++ b/mimium-web/src/lib.rs
@@ -33,7 +33,7 @@ pub struct Context {
 }
 
 fn get_default_context() -> ExecContext {
-    let mut ctx = ExecContext::new([].into_iter(), None);
+    let mut ctx = ExecContext::new([].into_iter(), None, Default::default());
     ctx.add_system_plugin(mimium_scheduler::get_default_scheduler_plugin());
     if let Some(midi_plug) = mimium_midi::MidiPlugin::try_new() {
         ctx.add_system_plugin(midi_plug);


### PR DESCRIPTION
Currently, the stateful function returns always 0 (or 0-ish value for aggregate types) at t=0.
This behavior made around a0d0baa5323b4ee0de9ffe651e379bccaf50a8ad.

`| |{self + 1}`

This is helpful, for example, when we read samples from array like this code.
```rust
let sampler = gen_sampler_mono("../assets/count_100_by_0_01_f32_48000Hz.wav")
fn counter(){
    self+1.0 
}
fn dsp(){
    counter() |> sampler
}
```

However, this spec is also problematic when we want to implement resettable counter like this.

```rust
fn counter(){
    self+1
}
fn integ(x, reset) {
  if (reset) {
    0
  } else {
    self + x
  }
}
fn dsp(){
    let count  = counter()
    let reset = count > 5
    let r = integ(1,reset)
    (reset,r)
}
```
This code generates sequence like 

```
ch0: 0,0,0,0,0,0,1,1,1,1
ch1: 0,1,2,3,4,5,6,0,0,0
```

which causes one-sample delay when the reset trigger signal is activated.

if `| |{self + 1}` is evaluated to 1 when t = 0, the result will be:
```
ch0: 0,0,0,0,0,1,1,1,1,1
ch1: 1,2,3,4,5,0,0,0,0,0
```

I think "1 when t=0" is more preferble because the zero-starting counter can still be implemented on the user side like this.

```rust
fn counter(){
  self+1
}
fn counter_from_zero(){
  counter() - 1
}
```

Now with this  PR, the counter returns 1 when t=0.  Also I added a new option to compiler `--self-init-0`, which switches the behavior to `0 when t=0`.

I implemented this flag also for future development of more configurable compiler but this specific option maybe unnecessary and removed in the future...
