### PR TITLE
[CI] Cache `.crates2.json` and `.crates.toml`

### DIFF
--- a/.github/workflows/ci_web.yaml
+++ b/.github/workflows/ci_web.yaml
@@ -4,8 +4,7 @@ on:
   pull_request:
     branches: [main, dev]
   push:
-    # branches: [main, dev]
-    branches: ["ci/cache-crates2.json"]
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci_web.yaml
+++ b/.github/workflows/ci_web.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main, dev]
   push:
     # branches: [main, dev]
-    branches: "*"
+    branches: ["ci/cache-crates2.json"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci_web.yaml
+++ b/.github/workflows/ci_web.yaml
@@ -30,6 +30,8 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            ~/.cargo/.crates2.json
+            ~/.cargo/.crates.toml
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install wasm-pack

--- a/.github/workflows/ci_web.yaml
+++ b/.github/workflows/ci_web.yaml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches: [main, dev]
   push:
-    branches: [main, dev]
+    # branches: [main, dev]
+    branches: "*"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request should fix this error. (Clearing cache might be needed)

```
error: binary `wasm-pack` already exists in destination
Add --force to overwrite
Error: Process completed with exit code 101.
```

It seems `cargo install` uses specific files to store information about the installed crates. This seems the same issue:

https://users.rust-lang.org/t/get-cargo-install-to-fail-silently-if-the-binary-already-exists/99507/2

The answer suggests to cache `~/.cargo/.crates.toml` and `~/.cargo/.crates2.json`. According to Cargo's document, these two files are used by `cargo install`. I'm not sure if both files are needed, but caching this just worked fine.

> `.crates.toml`, `.crates2.json`  These hidden files contain [package](https://doc.rust-lang.org/cargo/appendix/glossary.html#package) information of crates installed via [cargo install](https://doc.rust-lang.org/cargo/commands/cargo-install.html). Do NOT edit by hand!  
> (<https://doc.rust-lang.org/cargo/guide/cargo-home.html>)

Test run: https://github.com/yutannihilation/mimium-rs/actions/runs/12488356953/job/34850638474#step:5:10