### PR TITLE
Add simple slider UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,7 @@ dependencies = [
 name = "mimium-guitools"
 version = "2.3.1"
 dependencies = [
+ "atomic_float",
  "eframe",
  "egui",
  "egui_plot",

--- a/mimium-guitools/Cargo.toml
+++ b/mimium-guitools/Cargo.toml
@@ -20,3 +20,5 @@ eframe = { version = "0.29.1", default-features = false, features = [
     "persistence",   # Enable restoring app state when restarting the app.
 ] }
 ringbuf = "0.4.7"
+atomic_float = "*"
+

--- a/mimium-guitools/examples/plot.mmm
+++ b/mimium-guitools/examples/plot.mmm
@@ -18,7 +18,8 @@ let probel = make_probe("left")
 let prober = make_probe("right")
 
 fn dsp(){
-    let l = probel(amosc(fmosc(440,0.02) , 0.2))
-    let r = prober(amosc(fmosc(220,0.03) , 0.3))
+    let gain = ${Slider("gain",1.0,0.0,1.0)}
+    let l = probel(amosc(fmosc(440,0.02) , 0.2)*gain)
+    let r = prober(amosc(fmosc(220,0.03) , 0.3)*gain)
     (l,r)
 }

--- a/mimium-guitools/examples/plot.mmm
+++ b/mimium-guitools/examples/plot.mmm
@@ -1,25 +1,25 @@
+`{
 let pi = 3.14159265359
 let sr = 48000.0
-fn phasor(freq){
+let phasor= |freq|{
   (self + freq/sr)%1.0
 }
-fn osc(freq){
+let osc = |freq|{
   sin(phasor(freq)*pi*2.0)
 }
-fn fmosc(freq,rate){
+let fmosc = |freq,rate|{
   osc(freq + osc(rate)*4000.0)
 }
-fn amosc(input,rate){
+let amosc = |input,rate|{
    input * (osc(rate)+1.0/ 2)
 }
-
-
 let probel = make_probe("left")
 let prober = make_probe("right")
+let dsp = | |{
+    let gain2 = Slider!("gain2",0.5,0.0,1.0)
 
-fn dsp(){
-    let gain = ${Slider("gain",1.0,0.0,1.0)}
-    let l = probel(amosc(fmosc(440,0.02) , 0.2)*gain)
-    let r = prober(amosc(fmosc(220,0.03) , 0.3)*gain)
+    let l = probel(amosc(fmosc(440,0.02) , 0.2)* Slider!("gain",0.5,0.0,1.0))
+    let r = prober(amosc(fmosc(220,0.03) , 0.3)*gain2)
     (l,r)
+}
 }

--- a/mimium-guitools/examples/plot_and_midi.mmm
+++ b/mimium-guitools/examples/plot_and_midi.mmm
@@ -47,7 +47,7 @@ fn myadsr(gate){
 fn synth(note,vel){
     let sig = note |> midi_to_hz |> osc 
     let gain = vel /127.0;
-    sig *  gain
+    sig *  gain * ${ Slider("volume",1.0,0.0,1.0) }
 }
 
 let ch0  = bind_midi_note_mono(0.0,69.0,0.0);

--- a/mimium-guitools/src/lib.rs
+++ b/mimium-guitools/src/lib.rs
@@ -1,10 +1,14 @@
 use std::{cell::RefCell, rc::Rc};
 
 use mimium_lang::{
+    ast::{Expr, Literal},
     function,
     interner::{ToSymbol, TypeNodeId},
+    interpreter::Value,
     log, numeric,
-    plugin::{ExtClsInfo, SysPluginSignature, SystemPlugin, SystemPluginFnType},
+    plugin::{
+        ExtClsInfo, SysPluginSignature, SystemPlugin, SystemPluginFnType, SystemPluginMacroType,
+    },
     runtime::vm::{Machine, ReturnCode},
     string_t,
     types::{PType, Type},
@@ -33,7 +37,57 @@ impl GuiToolPlugin {
     fn get_closure_type() -> TypeNodeId {
         function!(vec![numeric!()], numeric!())
     }
+    const GET_SLIDER: &'static str = "__get_slider";
 
+    pub fn make_slider(&mut self, v: &[(Value, TypeNodeId)]) -> Value {
+        assert_eq!(v.len(), 4);
+        let (name, init, min, max, window) = match (
+            v[0].0.clone(),
+            v[1].0.clone(),
+            v[2].0.clone(),
+            v[3].0.clone(),
+            self.window.as_mut(),
+        ) {
+            (
+                Value::String(name),
+                Value::Number(init),
+                Value::Number(min),
+                Value::Number(max),
+                Some(window),
+            ) => (name, init, min, max, window),
+            _ => {
+                log::error!("invalid argument");
+                return Value::Number(0.0);
+            }
+        };
+        let idx = window.add_slider(name.as_str(), init, min, max);
+
+        Value::Code(
+            Expr::Apply(
+                Expr::Var(Self::GET_SLIDER.to_symbol()).into_id_without_span(),
+                vec![
+                    Expr::Literal(Literal::Float(idx.to_string().to_symbol()))
+                        .into_id_without_span(),
+                ],
+            )
+            .into_id_without_span(),
+        )
+    }
+    pub fn get_slider(&mut self, vm: &mut Machine) -> ReturnCode {
+        if let Some(window) = self.window.as_mut() {
+            let slider_idx = Machine::get_as::<f64>(vm.get_stack(0)) as usize;
+            match window.sliders.get(slider_idx) {
+                Some(s) => {
+                    vm.set_stack(0, Machine::to_value(s.get()));
+                }
+                None => {
+                    log::error!("invalid slider index");
+                    return 0;
+                }
+            };
+        }
+        1
+    }
     /// This method is exposed as "make_probe(label:String)->(float)->float".
     pub fn make_probe(&mut self, vm: &mut Machine) -> ReturnCode {
         if let Some(app) = self.window.as_mut() {
@@ -96,8 +150,23 @@ impl SystemPlugin for GuiToolPlugin {
     }
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
         let ty = function!(vec![string_t!()], Self::get_closure_type());
-        let fptr: SystemPluginFnType<Self> = Self::make_probe;
-        let make_probe = SysPluginSignature::new("make_probe", fptr, ty);
-        vec![make_probe]
+        let probef: SystemPluginFnType<Self> = Self::make_probe;
+        let make_probe = SysPluginSignature::new("make_probe", probef, ty);
+        let sliderf: SystemPluginMacroType<Self> = Self::make_slider;
+        let make_slider = SysPluginSignature::new_macro(
+            "Slider",
+            sliderf,
+            function!(
+                vec![string_t!(), numeric!(), numeric!()],
+                Type::Code(Type::Primitive(PType::Numeric).into_id()).into_id()
+            ),
+        );
+        let getsliderf: SystemPluginFnType<Self> = Self::get_slider;
+        let get_slider = SysPluginSignature::new(
+            Self::GET_SLIDER,
+            getsliderf,
+            function!(vec![numeric!()], numeric!()),
+        );
+        vec![make_probe, make_slider, get_slider]
     }
 }

--- a/mimium-guitools/src/plot_window.rs
+++ b/mimium-guitools/src/plot_window.rs
@@ -28,17 +28,17 @@ impl FloatParameter {
         }
     }
     pub fn get(&self) -> f64 {
-        self.value.load(Ordering::SeqCst)
+        self.value.load(Ordering::Relaxed)
     }
     pub fn set(&self, v: f64) {
-        self.value.store(v, Ordering::SeqCst)
+        self.value.store(v, Ordering::Relaxed)
     }
 }
 
 #[derive(Default)]
 pub struct PlotApp {
     plot: Vec<plot_ui::PlotUi>,
-    pub sliders: Vec<Arc<FloatParameter>>,
+    pub(crate) sliders: Vec<Arc<FloatParameter>>,
     hue: f32,
     autoscale: bool,
 }
@@ -63,10 +63,17 @@ impl PlotApp {
             Color32::from_rgba_premultiplied(r, g, b, 200),
         ))
     }
-    pub fn add_slider(&mut self, name: &str, init: f64, min: f64, max: f64) -> usize {
+    pub fn add_slider(
+        &mut self,
+        name: &str,
+        init: f64,
+        min: f64,
+        max: f64,
+    ) -> (Arc<FloatParameter>, usize) {
         let param = FloatParameter::new(name.to_string(), init, min, max);
-        self.sliders.push(Arc::new(param));
-        self.sliders.len() - 1
+        let p = Arc::new(param);
+        self.sliders.push(p.clone());
+        (p, self.sliders.len() - 1)
     }
     pub fn is_empty(&self) -> bool {
         self.plot.is_empty()

--- a/mimium-guitools/src/plot_window.rs
+++ b/mimium-guitools/src/plot_window.rs
@@ -1,13 +1,44 @@
+use std::{
+    ops::RangeInclusive,
+    sync::{
+        Arc,
+        atomic::{AtomicPtr, Ordering},
+    },
+};
+
 use crate::plot_ui::{self, PlotUi};
 use eframe;
 
+use atomic_float::AtomicF64;
 use egui::Color32;
 use egui_plot::{CoordinatesFormatter, Corner, Legend, Plot};
 use ringbuf::HeapCons;
 
+pub(crate) struct FloatParameter {
+    value: AtomicF64,
+    name: String,
+    range: RangeInclusive<f64>,
+}
+impl FloatParameter {
+    fn new(name: String, init: f64, min: f64, max: f64) -> Self {
+        Self {
+            value: AtomicF64::new(init),
+            name,
+            range: min..=max,
+        }
+    }
+    pub fn get(&self) -> f64 {
+        self.value.load(Ordering::SeqCst)
+    }
+    pub fn set(&self, v: f64) {
+        self.value.store(v, Ordering::SeqCst)
+    }
+}
+
 #[derive(Default)]
 pub struct PlotApp {
     plot: Vec<plot_ui::PlotUi>,
+    pub sliders: Vec<Arc<FloatParameter>>,
     hue: f32,
     autoscale: bool,
 }
@@ -17,6 +48,7 @@ impl PlotApp {
         let plot = vec![PlotUi::new_test("test")];
         Self {
             plot,
+            sliders: Vec::new(),
             hue: 0.0,
             autoscale: false,
         }
@@ -30,6 +62,11 @@ impl PlotApp {
             buf,
             Color32::from_rgba_premultiplied(r, g, b, 200),
         ))
+    }
+    pub fn add_slider(&mut self, name: &str, init: f64, min: f64, max: f64) -> usize {
+        let param = FloatParameter::new(name.to_string(), init, min, max);
+        self.sliders.push(Arc::new(param));
+        self.sliders.len() - 1
     }
     pub fn is_empty(&self) -> bool {
         self.plot.is_empty()
@@ -69,6 +106,23 @@ impl eframe::App for PlotApp {
             });
 
             ui.ctx().request_repaint();
+        });
+        egui::TopBottomPanel::bottom("parameters").show(ctx, |ui| {
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                for p in &self.sliders {
+                    let mut v = p.get();
+                    if ui
+                        .add(
+                            egui::Slider::new(&mut v, p.range.clone())
+                                .text(&p.name)
+                                .clamping(egui::SliderClamping::Always),
+                        )
+                        .changed()
+                    {
+                        p.set(v);
+                    }
+                }
+            });
         });
     }
 }

--- a/mimium-lang/src/compiler.rs
+++ b/mimium-lang/src/compiler.rs
@@ -135,6 +135,7 @@ impl Context {
             .clone()
             .into_iter()
             .map(|ExtFunTypeInfo { name, ty, .. }| (name, ty))
+            .chain(self.macros.iter().map(|m| (m.get_name(), m.get_type())))
             .collect()
     }
 

--- a/mimium-lang/src/plugin.rs
+++ b/mimium-lang/src/plugin.rs
@@ -73,6 +73,7 @@ pub type MacroFunType = Rc<RefCell<dyn Fn(&[(Value, TypeNodeId)]) -> Value>>;
 pub trait MacroFunction {
     //name is still needed for linking program
     fn get_name(&self) -> Symbol;
+    fn get_type(&self) -> TypeNodeId;
     /// Main macro function. If you need to receive 2 or more arguments, you need to pass struct or tuple as the argument instead.
     fn get_fn(&self) -> MacroFunType;
 }
@@ -108,7 +109,9 @@ impl MacroFunction for MacroInfo {
     fn get_name(&self) -> Symbol {
         self.name
     }
-
+    fn get_type(&self) -> TypeNodeId {
+        self.ty
+    }
     fn get_fn(&self) -> MacroFunType {
         self.fun.clone()
     }
@@ -217,6 +220,9 @@ impl MachineFunction for CommonFunction {
 impl MacroFunction for CommonFunction {
     fn get_name(&self) -> Symbol {
         self.name
+    }
+    fn get_type(&self) -> TypeNodeId {
+        self.ty
     }
     fn get_fn(&self) -> MacroFunType {
         Rc::new(RefCell::new(self.macro_fun))

--- a/mimium-lang/src/plugin.rs
+++ b/mimium-lang/src/plugin.rs
@@ -13,7 +13,7 @@ pub use builtin_functins::get_builtin_fns_as_plugins;
 use std::{cell::RefCell, rc::Rc};
 
 pub use system_plugin::{
-    DynSystemPlugin, SysPluginSignature, SystemPlugin, SystemPluginFnType,
+    DynSystemPlugin, SysPluginSignature, SystemPlugin, SystemPluginFnType, SystemPluginMacroType,
 };
 
 use crate::{

--- a/mimium-lang/src/plugin/system_plugin.rs
+++ b/mimium-lang/src/plugin/system_plugin.rs
@@ -52,7 +52,7 @@ impl SysPluginSignature {
     }
     pub fn new_macro<F, T>(name: &'static str, fun: F, ty: TypeNodeId) -> Self
     where
-        F: Fn(&mut T, &mut Machine) -> ReturnCode + 'static,
+        F: Fn(&mut T, &[(Value, TypeNodeId)]) -> Value + 'static,
         T: SystemPlugin,
     {
         Self {


### PR DESCRIPTION
This PR adds simple slider UI.

This `Slider` function is implemented as multi-stage evaluation macro, so that you can embed the function call directly in `dsp` context like the example below.

In the future, `make_probe` will also be replaced with `Probe` macro.

```rust
`{
let pi = 3.14159265359
let sr = 48000.0
let phasor= |freq|{
  (self + freq/sr)%1.0
}
let osc = |freq|{
  sin(phasor(freq)*pi*2.0)
}
let fmosc = |freq,rate|{
  osc(freq + osc(rate)*4000.0)
}
let amosc = |input,rate|{
   input * (osc(rate)+1.0/ 2)
}
let probel = make_probe("left")
let prober = make_probe("right")
let dsp = | |{
    let l = probel(amosc(fmosc(440,0.02) , 0.2)* Slider!("gain",0.5,0.0,1.0))
    let r = prober(amosc(fmosc(220,0.03) , 0.3)* Slider!("gain2",0.5,0.0,1.0))
    (l,r)
}
}
```


<img width="561" height="559" alt="スクリーンショット 2025-09-01 16 46 24" src="https://github.com/user-attachments/assets/22b2e06c-5d13-4f78-ae59-a9ae014caa99" />
